### PR TITLE
(fix) getProperty case sensitive "TribeId"

### DIFF
--- a/src/ArkFilesData.js
+++ b/src/ArkFilesData.js
@@ -196,7 +196,7 @@ class ArkFilesData {
             Players: [],
             Name: binaryParser.getProperty('TribeName'),
             OwnerId: binaryParser.getProperty('OwnerPlayerDataID'),
-            Id: binaryParser.getProperty('TribeID'),
+            Id: binaryParser.getProperty('TribeId'),
             TribeLogs: binaryParser.getProperty('TribeLog'),
             TribeMemberNames: binaryParser.getProperty('MembersPlayerName'),
             FileCreated: util.formatTime(fileData.birthtime),

--- a/src/ArkFilesData.js
+++ b/src/ArkFilesData.js
@@ -163,7 +163,7 @@ class ArkFilesData {
             Level: binaryParser.getProperty('CharacterStatusComponent_ExtraCharacterLevel') + 1,
             TotalEngramPoints: binaryParser.getProperty('PlayerState_TotalEngramPoints'),
             CharacterName: binaryParser.getProperty('PlayerCharacterName'),
-            TribeId: binaryParser.getProperty('TribeID'),
+            TribeId: binaryParser.getProperty('TribeId'),
             SteamId: binaryParser.getSteamId(),
             PlayerId: binaryParser.getProperty('PlayerDataID'),
             FileCreated: util.formatTime(fileData.birthtime),


### PR DESCRIPTION
In the ark data files the property is "TribeId". 
ArkFilesData.js was referencing it as "TribeID". This was causing TribeId to return false when getting players and tribes.